### PR TITLE
Test for 'auto' in calculateElementWidth

### DIFF
--- a/lib/jquery.renewal.js
+++ b/lib/jquery.renewal.js
@@ -42,8 +42,17 @@
         self = this;
 
     function calculateElementWidth(el) {
-      var marginLeft = parseInt(el.css('marginLeft'), 10),
-          marginRight = parseInt(el.css('marginRight'), 10);
+     var
+        cssMarginLeft,
+        marginLeft,
+        cssMarginRight,
+        marginRight;
+
+      cssMarginLeft = el.css('marginLeft');
+      cssMarginRight = el.css('marginRight');
+      marginLeft = (cssMarginLeft !== 'auto') ? parseInt(cssMarginLeft, 10) : 0;
+      marginRight = (cssMarginRight !== 'auto') ? parseInt(cssMarginRight, 10) : 0;
+
       return el.outerWidth() + marginLeft + marginRight;
     }
 

--- a/lib/jquery.renewal.js
+++ b/lib/jquery.renewal.js
@@ -42,16 +42,8 @@
         self = this;
 
     function calculateElementWidth(el) {
-     var
-        cssMarginLeft,
-        marginLeft,
-        cssMarginRight,
-        marginRight;
-
-      cssMarginLeft = el.css('marginLeft');
-      cssMarginRight = el.css('marginRight');
-      marginLeft = (cssMarginLeft !== 'auto') ? parseInt(cssMarginLeft, 10) : 0;
-      marginRight = (cssMarginRight !== 'auto') ? parseInt(cssMarginRight, 10) : 0;
+     var  marginLeft = parseInt(el.css('marginLeft'), 10) || 0,
+          marginRight = parseInt(el.css('marginRight'), 10) || 0;
 
       return el.outerWidth() + marginLeft + marginRight;
     }

--- a/spec/fixture-no-margin.html
+++ b/spec/fixture-no-margin.html
@@ -1,0 +1,20 @@
+<div>
+  <ul id="carousel" class="fixture carousel">
+    <li>1</li>
+    <li>2</li>
+    <li>3</li>
+  </ul>
+</div>
+
+<style>
+  .carousel {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .carousel li {
+    width: 50px;
+    list-style: none;
+    float: left;
+  }
+</style>

--- a/spec/jquery-renewal-spec.js
+++ b/spec/jquery-renewal-spec.js
@@ -1,8 +1,17 @@
 describe('jquery-renewal', function () {
   var
     calculateElementWidth = function (el) {
-      var marginLeft = parseInt(el.css('marginLeft'), 10),
-          marginRight = parseInt(el.css('marginRight'), 10);
+      var
+        cssMarginLeft,
+        marginLeft,
+        cssMarginRight,
+        marginRight;
+
+      cssMarginLeft = el.css('marginLeft');
+      cssMarginRight = el.css('marginRight');
+      marginLeft = (cssMarginLeft !== 'auto') ? parseInt(cssMarginLeft, 10) : 0;
+      marginRight = (cssMarginRight !== 'auto') ? parseInt(cssMarginRight, 10) : 0;
+
       return el.outerWidth() + marginLeft + marginRight;
     };
 
@@ -352,4 +361,39 @@ describe('jquery-renewal', function () {
     });
   });
 
+  describe('Carousel element have no margin', function () {
+    beforeEach(function () {
+      loadFixtures('fixture-no-margin.html');
+      this.element = $('#carousel');
+      this.element.renewal({
+        start: 1,
+        speed: 0
+      });
+      this.carousel = this.element.data('carousel');
+    });
+
+    it('should constrain the width of the wrapper', function () {
+      var firstItem = this.element.children(':first'),
+          wrapper = this.element.parent(),
+          firstItemWidth = calculateElementWidth(firstItem);
+      expect(wrapper.width()).toEqual(firstItemWidth);
+    });
+
+    describe('#moveTo', function () {
+
+      it('should move the left position of the element', function () {
+        this.carousel.moveTo(2, 0);
+        expect(this.element.css('left')).toEqual('-100px');
+      });
+
+      it('should move at any speed it would like to', function () {
+        var movement = this.carousel.moveTo(1, 500);
+        waits(1000);
+        runs(function () {
+          expect(this.element.css('left')).toEqual('-50px');
+        });
+      });
+    }); // #moveTo
+
+  }); // no margin
 });


### PR DESCRIPTION
Some older browsers will return 'auto' if no margin is specified,
rather than '0px'. This will cause parseInt to throw and error and
stop execution.
